### PR TITLE
chore: bump minSdk to 31

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,7 +44,7 @@ ComicViewer is a multi-platform comic viewer application supporting Android, iOS
 - **Kotlin**: 2.4.10
 - **Gradle**: 9.6.1
 - **Java**: 21 (Required)
-- **Android SDK**: compileSdk 37, minSdk 30
+- **Android SDK**: compileSdk 37, minSdk 31
 - **Modular Architecture**: feature/domain/data layer structure
 - **Metro**: Dependency injection framework
 - **Room**: Database (Android)
@@ -63,7 +63,7 @@ ComicViewer is a multi-platform comic viewer application supporting Android, iOS
 
 2. **Android SDK**
     - API 37 (compileSdk)
-    - Minimum API 30 (minSdk)
+    - Minimum API 31 (minSdk)
     - Android SDK Build-Tools
 
 3. **Network Access**

--- a/framework/designsystem/src/androidMain/kotlin/com/sorrowblue/comicviewer/framework/designsystem/theme/ColorScheme.android.kt
+++ b/framework/designsystem/src/androidMain/kotlin/com/sorrowblue/comicviewer/framework/designsystem/theme/ColorScheme.android.kt
@@ -4,7 +4,6 @@
 
 package com.sorrowblue.comicviewer.framework.designsystem.theme
 
-import android.os.Build
 import androidx.compose.material3.dynamicDarkColorScheme
 import androidx.compose.material3.dynamicLightColorScheme
 import androidx.compose.runtime.Composable
@@ -12,7 +11,7 @@ import androidx.compose.ui.platform.LocalContext
 
 @Composable
 internal actual fun colorScheme(darkTheme: Boolean, dynamicColor: Boolean) = when {
-    dynamicColor && Build.VERSION.SDK_INT >= Build.VERSION_CODES.S -> {
+    dynamicColor -> {
         val context = LocalContext.current
         if (darkTheme) dynamicDarkColorScheme(context) else dynamicLightColorScheme(context)
     }

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -18,7 +18,7 @@ plugins {
 
 android {
     compileSdk = 37
-    minSdk = 30
+    minSdk = 31
 }
 
 kover {


### PR DESCRIPTION
## Changes
Androidの最小APIレベル（`minSdk`）を30（Android 11）から31（Android 12, S）に引き上げました。

- `settings.gradle.kts` の `minSdk` を `31` に変更
- `AGENTS.md` 内の最小 SDK 動作要件の記述を `31` に更新
- `ColorScheme.android.kt` で `Build.VERSION.SDK_INT >= Build.VERSION_CODES.S` 条件が常に真となるため、不要なバージョン判定条件と `Build` のインポートを削除

## Related Issues
なし

## Testing Method
- `.\gradlew.bat :app:androidApp:assembleDebug` のビルドが成功することを確認。
- `.\gradlew.bat allTests` ですべてのユニットテストが成功することを確認。

## Checklist
- [x] Detekt executed
- [x] Lint executed
- [x] Tests executed
- [x] Documentation updated
