### PR TITLE
refactor: update and pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/actions/setup-java-gradle/action.yml
+++ b/.github/actions/setup-java-gradle/action.yml
@@ -3,7 +3,7 @@ runs:
   using: "composite"
   steps:
     - name: Setup JDK 21
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v5.5.0
       with:
         java-version: '21'
         distribution: 'temurin'
@@ -11,4 +11,4 @@ runs:
       shell: bash
       run: chmod +x ./gradlew
     - name: Setup Gradle
-      uses: gradle/actions/setup-gradle@v6
+      uses: gradle/actions/setup-gradle@0f4528296b4bc09e8ae0fc7be30185a4ab435545 # v6.0.0

--- a/.github/workflows/android-publish.yml
+++ b/.github/workflows/android-publish.yml
@@ -38,7 +38,7 @@ jobs:
     environment: android
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Setup Java and Gradle
@@ -80,7 +80,7 @@ jobs:
       play-url: ${{ steps.resolve-url.outputs.play-url }}
     steps:
       - name: Download artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: artifacts/
       - name: Print
@@ -88,13 +88,13 @@ jobs:
           find ./artifacts
       - name: Authenticate to Google Cloud
         id: auth
-        uses: google-github-actions/auth@v3
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           workload_identity_provider: ${{ secrets.GOOGLE_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GOOGLE_SERVICE_ACCOUNT }}
       - name: Upload to Google Play
         id: upload
-        uses: r0adkll/upload-google-play@v1
+        uses: r0adkll/upload-google-play@e738b9dd8f2476ea806d921b64aacd24f34515a5 # v1
         with:
           serviceAccountJson: ${{ steps.auth.outputs.credentials_file_path }}
           packageName: com.sorrowblue.comicviewer

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     environment: android
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Decode android keystore file
@@ -36,7 +36,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Run packageDistributionForCurrentOS

--- a/.github/workflows/cache-clear.yml
+++ b/.github/workflows/cache-clear.yml
@@ -7,4 +7,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Delete Branch Cache
-        uses: snnaplab/delete-branch-cache-action@v1
+        uses: snnaplab/delete-branch-cache-action@20f7992a7b8b51aa719420d11b32c9d34a5eb362 # v1

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -21,15 +21,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Setup JDK and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Generate Dokka
         timeout-minutes: 30
         run: ./gradlew dokkaGenerate --max-workers=1
-      - uses: actions/upload-artifact@v7
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         id: artifact-upload-step
         with:
           name: kdoc-html
@@ -44,7 +44,7 @@ jobs:
     needs: generate
     steps:
       - name: Download KDoc artifact
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           name: kdoc-html
       - name: Move dokka html to root dokka/
@@ -58,9 +58,9 @@ jobs:
           rm -rf docs
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v6
+        uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@v1
+        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.12
         with:
           source: ./
       - name: Archive artifact
@@ -76,7 +76,7 @@ jobs:
             .
           echo "::endgroup::"
       - name: Upload artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: github-pages
           path: ${{ runner.temp }}/artifact.tar
@@ -92,5 +92,5 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/deploy-pages@v5
+      - uses: actions/deploy-pages@cd2ce8fcbc39b97be8ca5fce6e763baed58fa128 # v5.0.0
         id: deployment

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Discord
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           nodetail: true

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -26,7 +26,7 @@ jobs:
       should-run: ${{ steps.check.outputs.should-run }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 2
       - name: Get changed files
@@ -79,7 +79,7 @@ jobs:
     if: always() && cancelled() != true && needs.check-commit.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: wechuli/allcheckspassed@v2
+      - uses: wechuli/allcheckspassed@204ff63e89eabdc8086f0c50b91f675bcf37c8f6 # v2
         with:
           poll: false
           delay: 0

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,13 +43,13 @@ jobs:
     name: 🔍️ ${{ matrix.name || matrix.task }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: 🔍️Run analyze ${{ matrix.name || matrix.task }}
         run: ./gradlew ${{ matrix.task }}
       - name: Upload SARIF
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4
         if: ${{ !cancelled() && matrix.sarif_file && matrix.category }}
         with:
           sarif_file: ${{ matrix.sarif_file }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -35,7 +35,7 @@ jobs:
 
       # Drafts your next Release notes as Pull Requests are merged into "master"
       - name: Update Release Draft
-        uses: release-drafter/release-drafter@v7
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
         # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
           commitish: main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,7 +50,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: Run packageDistributionForCurrentOS
@@ -66,20 +66,20 @@ jobs:
     needs: [ android-publish, windows-publish, build-jvm-release ]
     steps:
       - name: Download all artifacts
-        uses: actions/download-artifact@v8
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:
           path: ./artifacts
       - name: Display structure of downloaded files
         run: ls -la ./artifacts/**
       - name: Upload Release Assets
-        uses: softprops/action-gh-release@v3
+        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228 # v3
         if: github.event_name == 'release'
         with:
           files: |
             ./artifacts/jvm-Ubuntu/deb/*
             ./artifacts/jvm-Mac/dmg/*
       - name: Notify Discord - Release Success
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           nodetail: true
@@ -97,7 +97,7 @@ jobs:
           color: 0x00ff00
       - name: Notify Discord - Failure
         if: failure()
-        uses: sarisia/actions-status-discord@v1
+        uses: sarisia/actions-status-discord@eb045afee445dc055c18d3d90bd0f244fd062708 # v1
         with:
           webhook: ${{ secrets.DISCORD_WEBHOOK }}
           nodetail: true

--- a/.github/workflows/sync-labels.yml
+++ b/.github/workflows/sync-labels.yml
@@ -15,9 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Node.js
-        uses: actions/setup-node@v7
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
       - name: Install dependencies

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           -PsmbPath="/testshare/testfolder/"
       - name: Upload Test Report
         if: cancelled() != true
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: 'Unit Test'
           path: '**/build/test-results/*/TEST-*.xml'
@@ -66,7 +66,7 @@ jobs:
           sudo udevadm control --reload-rules
           sudo udevadm trigger --name-match=kvm
       - name: AVD cache
-        uses: actions/cache@v6
+        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
         id: avd-cache
         with:
           path: |
@@ -75,7 +75,7 @@ jobs:
           key: avd-35
       - name: create AVD and generate snapshot for caching
         if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 35
           target: aosp_atd
@@ -86,7 +86,7 @@ jobs:
           disable-animations: false
           script: echo "Generated AVD snapshot for caching."
       - name: Run Instrumentation tests
-        uses: reactivecircus/android-emulator-runner@v2
+        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
         with:
           api-level: 35
           target: aosp_atd
@@ -104,7 +104,7 @@ jobs:
             -PsmbPath="/testshare/testfolder/"
       - name: Upload Test Report
         if: cancelled() != true
-        uses: dorny/test-reporter@v3
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
           name: 'Instrumentation Test'
           path: '**/build/outputs/*Test-results/**/TEST-*.xml'

--- a/.github/workflows/update-licenses.yml
+++ b/.github/workflows/update-licenses.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
       - name: 🤖 ExportLibraryDefinitions for android
@@ -32,7 +32,7 @@ jobs:
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v8
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8
         with:
           token: ${{ secrets.PAT }}
           title: 'Update aboutlibraries.json'
@@ -46,7 +46,7 @@ jobs:
 
       - name: Enable Auto Merge
         if: steps.cpr.outputs.pull-request-operation == 'created'
-        uses: peter-evans/enable-pull-request-automerge@v3
+        uses: peter-evans/enable-pull-request-automerge@a660677d5469627102a1c1e11409dd063606628d # v3
         with:
           token: ${{ secrets.PAT }}
           pull-request-number: ${{ steps.cpr.outputs.pull-request-number }}

--- a/.github/workflows/windows-publish.yml
+++ b/.github/workflows/windows-publish.yml
@@ -12,7 +12,7 @@ jobs:
   jvm-build:
     runs-on: windows-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Setup JDK and Gradle
@@ -30,7 +30,7 @@ jobs:
     needs: jvm-build
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
 
@@ -48,7 +48,7 @@ jobs:
       # Test Flight
       - name: Build MSIX Package for Test Flight
         if: inputs.channel == 'test-flight'
-        uses: hydraulic-software/conveyor/actions/build@v22.0
+        uses: hydraulic-software/conveyor/actions/build@5011cc412f9c3a67d8f72f9ea5db5f34c4a68e36 # v22.1
         with:
           command: -f ci.conveyor.conf make windows-msix
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}
@@ -66,7 +66,7 @@ jobs:
       # Production
       - name: Run Conveyor to release to Microsoft Store (Production)
         if: inputs.channel == 'production'
-        uses: hydraulic-software/conveyor/actions/build@v22.0
+        uses: hydraulic-software/conveyor/actions/build@5011cc412f9c3a67d8f72f9ea5db5f34c4a68e36 # v22.1
         with:
           command: -f ci.conveyor.conf make ms-store-release
           signing_key: ${{ secrets.CONVEYOR_SIGNING_KEY }}


### PR DESCRIPTION
## Changes
GitHub Actionsで利用している外部アクションのバージョン指定をコミットSHAに厳格化（ピン留め）し、併せて最新のメジャー/マイナーバージョンへのアップデートを行いました。

## Checklist
- [x] Pinned to commit SHAs
- [x] Updated to latest versions