### PR TITLE
chore: Replace actions/jekyll-build-pages with ruby/setup-ruby

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -46,6 +46,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: generate
     steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Download KDoc artifact
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8
         with:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -60,7 +60,7 @@ jobs:
           cp -a docs/. ./
           rm -rf docs
       - name: Setup Ruby
-        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f3ec1aec69527ad90 # v1.193.0
+        uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b # v1.321.0
         with:
           ruby-version: '3.3'
           bundler-cache: true
@@ -70,7 +70,7 @@ jobs:
       - name: Build with Jekyll
         run: bundle exec jekyll build --source ./ --destination ./_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffbe7e37975b403859a41 # v3.0.1
+        uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5.0.0
         with:
           path: ./_site
   deploy:

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,9 +5,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    branches:
-      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -76,7 +73,6 @@ jobs:
         with:
           path: ./_site
   deploy:
-    if: github.event_name != 'pull_request'
     needs: jekyll-build
     permissions:
       id-token: write

--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -5,6 +5,9 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    branches:
+      - main
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -56,33 +59,22 @@ jobs:
         run: |
           cp -a docs/. ./
           rm -rf docs
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@ec02537da5712d66d4d50a0f3ec1aec69527ad90 # v1.193.0
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - name: Build with Jekyll
-        uses: actions/jekyll-build-pages@44a6e6beabd48582f863aeeb6cb2151cc1716697 # v1.0.12
-        with:
-          source: ./
-      - name: Archive artifact
-        shell: sh
-        run: |
-          echo "::group::Archive artifact"
-          tar \
-            --dereference --hard-dereference \
-            --directory "_site" \
-            -cvf "$RUNNER_TEMP/artifact.tar" \
-            --exclude=.git \
-            --exclude=.github \
-            .
-          echo "::endgroup::"
+        run: bundle exec jekyll build --source ./ --destination ./_site
       - name: Upload artifact
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        uses: actions/upload-pages-artifact@56afc609e74202658d3ffbe7e37975b403859a41 # v3.0.1
         with:
-          name: github-pages
-          path: ${{ runner.temp }}/artifact.tar
-          retention-days: 1
-          if-no-files-found: error
+          path: ./_site
   deploy:
+    if: github.event_name != 'pull_request'
     needs: jekyll-build
     permissions:
       id-token: write

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "jekyll", "~> 4.3.3"
+gem "jekyll-theme-cayman", "~> 0.2.0"
+gem "webrick", "~> 1.8"


### PR DESCRIPTION
## Changes
- メンテされていない `actions/jekyll-build-pages` を廃止し、`ruby/setup-ruby` と `bundle exec jekyll build` による最新のビルド構成に移行しました。
- Jekyllの依存関係管理のため、プロジェクトルートに `Gemfile` を新規追加しました。
- `actions/upload-pages-artifact` を利用したPages標準のアーティファクト生成に移行しました。
- 一時的な動作確認のため、`gh-pages` ワークフローのトリガーイベントに `pull_request` を追加しました。
- PRビルド時に意図しないデプロイが走らないよう、`deploy` ジョブに `if: github.event_name != 'pull_request'` の実行条件を追加しました。

## Related Issues
なし

## Testing Method
1. PR作成後、GitHub Actionsで `generate` および `jekyll-build` ジョブが正常に実行されることを確認する。
2. PRビルドにおいて `deploy` ジョブが「Skipped」となり、デプロイが実行されないことを確認する。
3. mainブランチへのプッシュ時にビルドおよびデプロイ（`deploy` ジョブ）まで正常に実行されることを確認する。

## Checklist
- [x] Detekt executed
- [x] Lint executed
- [x] Tests executed
- [x] Documentation updated
