### PR TITLE
chore: Migrate CI instrumentation tests to Gradle Managed Devices

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,49 +54,19 @@ jobs:
       samba: *samba_settings
 
     steps:
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
       - name: Setup samba
         uses: ./.github/actions/setup_samba
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-      - name: AVD cache
-        uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
-        id: avd-cache
-        with:
-          path: |
-            ~/.android/avd/*
-            ~/.android/adb*
-          key: avd-35
-      - name: create AVD and generate snapshot for caching
-        if: steps.avd-cache.outputs.cache-hit != 'true'
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
-        with:
-          api-level: 35
-          target: aosp_atd
-          arch: x86_64
-          profile: pixel_7_pro
-          force-avd-creation: false
-          emulator-options: -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: false
-          script: echo "Generated AVD snapshot for caching."
       - name: Run Instrumentation tests
-        uses: reactivecircus/android-emulator-runner@a421e43855164a8197daf9d8d40fe71c6996bb0d # v2
-        with:
-          api-level: 35
-          target: aosp_atd
-          arch: x86_64
-          profile: pixel_7_pro
-          force-avd-creation: false
-          emulator-options: -no-snapshot-save -no-window -gpu swiftshader_indirect -noaudio -no-boot-anim -camera-back none
-          disable-animations: true
-          script: >
-            ./gradlew connectedAndroidDeviceTest --continue
+        run: ./gradlew pixel7pro35AndroidDeviceTest --continue
             -PsmbHost=10.0.2.2
             -PsmbPort=445
             -PsmbUsername=testuser

--- a/app/share/build.gradle.kts
+++ b/app/share/build.gradle.kts
@@ -42,6 +42,12 @@ kotlin {
                         apiLevel = 35
                         systemImageSource = "aosp-atd"
                     }
+                    @Suppress("UnstableApiUsage")
+                    create("pixel7pro35") {
+                        device = "Pixel 7 Pro"
+                        apiLevel = 35
+                        systemImageSource = "aosp-atd"
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 概要
CI (GitHub Actions) 上の Android 共通テスト（Instrumentation Test）を、手動でエミュレータを起動・キャッシュする方式から **Gradle Managed Devices (GMD)** を利用する方式へと移行しました。

## 変更内容
1. **`app/share/build.gradle.kts`**:
   - GMD 用のデバイス定義として `pixel7pro35` (Pixel 7 Pro, API 35, aosp-atd) を新しく追加しました。
2. **`.github/workflows/test.yml`**:
   - `reactivecircus/android-emulator-runner` アクションおよび手動での AVD キャッシュ処理 (`actions/cache`) を完全に削除しました。
   - `Enable KVM group perms` ステップは KVM 仮想化を有効にするために残し、Checkout の前に配置しました。
   - テストコマンドを GMD 実行用の `./gradlew pixel7pro35AndroidDeviceTest --continue` に差し替えました。

## メリット
- CI ワークフロー定義ファイルが大幅に簡素化され、メンテナンスコストが減少します。
- GMD 組み込みのスナップショット（Quick Boot）管理に頼ることで、手動キャッシュの不整合による不具合を排除しつつ高速で安定したテストを実行できます。
