### PR TITLE
chore: split release-drafter configurations into stable and beta

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -1,4 +1,4 @@
-_extends: .github/release-drafter.yml
+_extends: release-drafter.yml
 prerelease: true
 include-pre-releases: true
 prerelease-identifier: 'beta'

--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -1,0 +1,6 @@
+_extends: release-drafter
+prerelease: true
+include-pre-releases: true
+prerelease-identifier: 'beta'
+name-template: 'v$RESOLVED_VERSION-beta 🌈'
+tag-template: 'v$RESOLVED_VERSION-beta'

--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -1,4 +1,4 @@
-_extends: release-drafter
+_extends: .github/release-drafter.yml
 prerelease: true
 include-pre-releases: true
 prerelease-identifier: 'beta'

--- a/.github/release-drafter-stable.yml
+++ b/.github/release-drafter-stable.yml
@@ -1,3 +1,3 @@
-_extends: .github/release-drafter.yml
+_extends: release-drafter.yml
 prerelease: false
 include-pre-releases: false

--- a/.github/release-drafter-stable.yml
+++ b/.github/release-drafter-stable.yml
@@ -1,0 +1,3 @@
+_extends: release-drafter
+prerelease: false
+include-pre-releases: false

--- a/.github/release-drafter-stable.yml
+++ b/.github/release-drafter-stable.yml
@@ -1,3 +1,3 @@
-_extends: release-drafter
+_extends: .github/release-drafter.yml
 prerelease: false
 include-pre-releases: false

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -83,8 +83,3 @@ autolabeler:
     branch:
       - '/^chore[/-].+/'
 
-prerelease: true
-
-include-pre-releases: true
-
-prerelease-identifier: 'beta'

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,27 +19,30 @@ permissions:
 jobs:
   update_release_draft:
     permissions:
-      # write permission is required to create a github release
       contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
       pull-requests: write
-      # Fix create labels error
       issues: write
     runs-on: ubuntu-latest
     steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - name: Update Release Draft
+      - name: Update Stable Release Draft
         uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
         with:
+          config-name: release-drafter-stable.yml
           commitish: main
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  update_prerelease_draft:
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Update Beta Release Draft
+        uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7
+        with:
+          config-name: release-drafter-beta.yml
+          commitish: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## 変更の概要
ベータ版（プリリリース）での変更内容が、最終的な正式リリースのリリースノートに漏れなく含まれるようにするため、Release Drafterの設定を分離しました。

## 変更内容
- `.github/release-drafter.yml` からプリリリース関連の設定を削除し、共通設定（カテゴリ、自動ラベル定義）のみに変更。
- `.github/release-drafter-beta.yml`（ベータ用）を新規作成 (`include-pre-releases: true`)。
- `.github/release-drafter-stable.yml`（正式版用）を新規作成 (`include-pre-releases: false`)。
- `.github/workflows/release-drafter.yml` を更新し、上記2つの設定ファイルを使用するジョブに分割。

## テスト方法
- YAMLの構文チェックを行い、問題ないことを確認。
