### PR TITLE
fix: remove duplicate beta suffix from release draft version

### DIFF
--- a/.github/release-drafter-beta.yml
+++ b/.github/release-drafter-beta.yml
@@ -2,5 +2,3 @@ _extends: release-drafter.yml
 prerelease: true
 include-pre-releases: true
 prerelease-identifier: 'beta'
-name-template: 'v$RESOLVED_VERSION-beta 🌈'
-tag-template: 'v$RESOLVED_VERSION-beta'


### PR DESCRIPTION
## Changes
ドラフトリリースの作成時にプレリリース（beta）バージョンの末尾に `-beta` が重複して付与される問題を修正しました。
`.github/release-drafter-beta.yml` にて `name-template` と `tag-template` の指定を削除しました。これにより、`prerelease-identifier: 'beta'` で自動付与される `-beta` サフィックスをそのまま使用するようになります。

## Related Issues
なし

## Testing Method
設定ファイルの変更のため、GitHub Actions上での動作確認となります。
