### PR TITLE
fix: align Skiko version across modules and packages

### DIFF
--- a/config/conveyor/conveyor.conf
+++ b/config/conveyor/conveyor.conf
@@ -20,7 +20,7 @@ app {
     include required("extra-header.conf")
   }
 
-  skiko-version = "0.144.6"
+  skiko-version = "0.150.1"
   maven-repo = "https://repo1.maven.org/maven2"
 
   linux {

--- a/data/coil/build.gradle.kts
+++ b/data/coil/build.gradle.kts
@@ -23,5 +23,15 @@ kotlin {
                 implementation(libs.androidx.startupRuntime)
             }
         }
+        jvmMain {
+            dependencies {
+                implementation(libs.compose.ui)
+            }
+        }
+        iosMain {
+            dependencies {
+                implementation(libs.compose.ui)
+            }
+        }
     }
 }


### PR DESCRIPTION
## Changes
- `config/conveyor/conveyor.conf` 内の `skiko-version` を `0.150.1` に更新し、パッケージに同梱されるネイティブライブラリのバージョンを Compose Multiplatform のバージョンと同期させました。
- `:data:coil` モジュールの `jvmMain` および `iosMain` ソースセットの依存関係に `libs.compose.ui` を追加しました。これにより、Compose が使用する Skiko のバージョン（`0.150.1`）がコンパイル時にも推移的に解決されるようになり、画像リサイズ処理（`Image.encodeToData`）を呼び出す際の `NoSuchMethodError` を解消しました。

## Related Issues
Fixed #1332

## Testing Method
1. `./gradlew :app:jvmApp:run` を実行し、ファイル一覧画面でサムネイル画像（BookThumbnail, FolderThumbnail）が正常に表示されることを確認しました。
2. `./gradlew :app:androidApp:compileDebugSources` および `./gradlew :data:coil:compileKotlinIosArm64` が正常に成功することを確認しました。

## Checklist
- [x] Detekt executed
- [x] Lint executed
- [x] Tests executed
- [x] Documentation updated
