### PR TITLE
fix: fallback defaultViewModelProviderFactory in MainActivity

### DIFF
--- a/app/share/src/androidMain/kotlin/com/sorrowblue/comicviewer/app/MainActivity.kt
+++ b/app/share/src/androidMain/kotlin/com/sorrowblue/comicviewer/app/MainActivity.kt
@@ -8,7 +8,6 @@ import android.app.Activity
 import android.content.Intent
 import android.graphics.Color
 import android.os.Bundle
-import androidx.activity.ComponentActivity
 import androidx.activity.SystemBarStyle
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
@@ -19,6 +18,7 @@ import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.splashscreen.SplashScreenViewProvider
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewmodel.CreationExtras
 import com.sorrowblue.comicviewer.app.ComicViewerAppViewModel.Factory
 import com.sorrowblue.comicviewer.feature.book.navigation.ReceiveBookNavKey
 import dev.zacsweers.metro.AppScope
@@ -33,8 +33,24 @@ import dev.zacsweers.metrox.viewmodel.MetroViewModelFactory
  */
 @ContributesIntoMap(AppScope::class, binding<Activity>())
 @ActivityKey
-internal class MainActivity(override val defaultViewModelProviderFactory: MetroViewModelFactory) :
+internal class MainActivity(private val metroViewModelFactory: MetroViewModelFactory) :
     AppCompatActivity() {
+
+    override val defaultViewModelProviderFactory: ViewModelProvider.Factory by lazy {
+        val superFactory = super.defaultViewModelProviderFactory
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T = runCatching {
+                metroViewModelFactory.create(modelClass)
+            }.getOrElse { superFactory.create(modelClass) }
+
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T =
+                runCatching {
+                    metroViewModelFactory.create(modelClass, extras)
+                }.getOrElse {
+                    superFactory.create(modelClass, extras)
+                }
+        }
+    }
 
     private val viewModel: ComicViewerAppViewModel by metroViewModel { factory: Factory ->
         factory.create(receivedBookData.isNullOrEmpty())
@@ -85,17 +101,26 @@ internal class MainActivity(override val defaultViewModelProviderFactory: MetroV
         categories == null || allowedCategories.any { hasCategory(it) }
 
     private val allowedCategories = listOf(Intent.CATEGORY_BROWSABLE, Intent.CATEGORY_DEFAULT)
-}
 
-private inline fun <reified T : ManualViewModelAssistedFactory, reified VM : ViewModel> ComponentActivity.metroViewModel(
-    crossinline creationCallback: (T) -> VM,
-): Lazy<VM> = viewModels<VM> {
-    object : ViewModelProvider.Factory {
-        override fun <T : ViewModel> create(modelClass: Class<T>): T {
-            val factory =
-                this@metroViewModel.defaultViewModelProviderFactory as MetroViewModelFactory
-            @Suppress("UNCHECKED_CAST")
-            return creationCallback(factory.createManuallyAssistedFactory(T::class).invoke()) as T
+    private inline fun <reified T : ManualViewModelAssistedFactory, reified VM : ViewModel> metroViewModel(
+        crossinline creationCallback: (T) -> VM,
+    ): Lazy<VM> = viewModels<VM> {
+        object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val factory = metroViewModelFactory
+                @Suppress("UNCHECKED_CAST")
+                return creationCallback(
+                    factory.createManuallyAssistedFactory(T::class).invoke(),
+                ) as T
+            }
+
+            override fun <T : ViewModel> create(modelClass: Class<T>, extras: CreationExtras): T {
+                val factory = metroViewModelFactory
+                @Suppress("UNCHECKED_CAST")
+                return creationCallback(
+                    factory.createManuallyAssistedFactory(T::class).invoke(),
+                ) as T
+            }
         }
     }
 }

--- a/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
+++ b/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
@@ -26,7 +26,6 @@ import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilDoesNotExist
 import com.sorrowblue.comicviewer.domain.model.bookshelf.BookshelfType
 import com.sorrowblue.comicviewer.framework.ui.core.isCompactWindowClass
-import com.sorrowblue.comicviewer.framework.ui.navigation.Navigator
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -61,28 +60,17 @@ class NavigationTest {
 
     private fun runComicViewerAppTest(block: suspend ComposeUiTest.() -> Unit) {
         runComposeUiTest {
-            var navigator: Navigator? = null
             setContent {
                 isCompact = isCompactWindowClass()
                 context(appGraph.context) {
                     MetroContent {
-                        val nav = rememberAppNavigator()
-                        navigator = nav
-                        ComicViewerApp(finishApp = {}, navigator = nav)
+                        ComicViewerApp(finishApp = {})
                         AppContent(appGraph)
                     }
                 }
             }
             tutorial()
-            try {
-                block()
-            } finally {
-                navigator?.let { nav ->
-                    nav.state.backStacks.values.forEach { stack ->
-                        stack.clear()
-                    }
-                }
-            }
+            block()
         }
     }
 

--- a/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
+++ b/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.test.waitUntilAtLeastOneExists
 import androidx.compose.ui.test.waitUntilDoesNotExist
 import com.sorrowblue.comicviewer.domain.model.bookshelf.BookshelfType
 import com.sorrowblue.comicviewer.framework.ui.core.isCompactWindowClass
+import com.sorrowblue.comicviewer.framework.ui.navigation.Navigator
 import kotlin.test.AfterTest
 import kotlin.test.BeforeTest
 import kotlin.test.Test
@@ -60,17 +61,28 @@ class NavigationTest {
 
     private fun runComicViewerAppTest(block: suspend ComposeUiTest.() -> Unit) {
         runComposeUiTest {
+            var navigator: Navigator? = null
             setContent {
                 isCompact = isCompactWindowClass()
                 context(appGraph.context) {
                     MetroContent {
-                        ComicViewerApp(finishApp = {})
+                        val nav = rememberAppNavigator()
+                        navigator = nav
+                        ComicViewerApp(finishApp = {}, navigator = nav)
                         AppContent(appGraph)
                     }
                 }
             }
             tutorial()
-            block()
+            try {
+                block()
+            } finally {
+                navigator?.let { nav ->
+                    nav.state.backStacks.values.forEach { stack ->
+                        stack.clear()
+                    }
+                }
+            }
         }
     }
 

--- a/build-logic/src/main/kotlin/com/sorrowblue/comicviewer/VersionUtils.kt
+++ b/build-logic/src/main/kotlin/com/sorrowblue/comicviewer/VersionUtils.kt
@@ -36,4 +36,3 @@ fun extractPackageVersion(versionName: String): String {
 
     return "$major.$minor.$newPatch"
 }
-


### PR DESCRIPTION
## Changes
- MainActivity の defaultViewModelProviderFactory の実装にフォールバックロジックを追加し、生体認証（BiometricViewModel）の生成失敗による起動時クラッシュを修正しました。
- UnsupportedOperationException に対処するため、CreationExtras 付きの create メソッドのオーバーロードも実装しました。
- metroViewModel 拡張関数を MainActivity 内の private インラインメンバ関数としてリファクタリングし、可視性の問題を解決しました。

## Testing Method
- デバッグビルドの作成確認済