### PR TITLE
enhancement: Support Protobuf serialization for settings and migrate BottomSheet API

### DIFF
--- a/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
+++ b/app/share/src/commonTest/kotlin/com/sorrowblue/comicviewer/app/NavigationTest.kt
@@ -99,7 +99,10 @@ class NavigationTest {
 
         onAllNodesWithTag("BookshelfFab").onFirst().performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         if (isCompact) {
@@ -113,7 +116,10 @@ class NavigationTest {
 
         onAllNodesWithTag("BookshelfFab").onFirst().performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         onNodeWithTag("BookshelfSelectionItem-${BookshelfType.SMB}").performClick()
@@ -123,7 +129,10 @@ class NavigationTest {
 
         onNodeWithTag("BackButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         onNodeWithTag("BookshelfSelectionItem-${BookshelfType.DEVICE}").performClick()
@@ -133,7 +142,10 @@ class NavigationTest {
 
         onNodeWithTag("BackButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         onNodeWithTag("BookshelfSelectionItem-${BookshelfType.SMB}").performClick()
@@ -196,7 +208,10 @@ class NavigationTest {
 
         onNodeWithTag("AddCollectionButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BasicCollectionAddScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BasicCollectionAddScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BasicCollectionAddScreenRoot").assertIsDisplayed()
 
         onAllNodesWithTag("CloseButton").onLast().performClick()
@@ -234,7 +249,10 @@ class NavigationTest {
 
         onNodeWithTag("SmartCollectionButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("SmartCollectionCreateScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("SmartCollectionCreateScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("SmartCollectionCreateScreenRoot").assertIsDisplayed()
 
         onAllNodesWithTag("CloseButton").onLast().performClick()
@@ -252,7 +270,10 @@ class NavigationTest {
         onNodeWithTag("BookshelfScreenRoot").assertIsDisplayed()
         onAllNodesWithTag("BookshelfFab").onFirst().performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         // 2. SMB本棚を選択してEditor画面へ
@@ -294,7 +315,10 @@ class NavigationTest {
 
         onNodeWithTag("ConfirmButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BookshelfSelectionList"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BookshelfSelectionList"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BookshelfSelectionList").assertIsDisplayed()
 
         // 8. Selectionから一覧画面へ戻る
@@ -329,22 +353,37 @@ class NavigationTest {
         onNodeWithTag("BookshelfScreenRoot").assertIsDisplayed()
 
         onAllNodesWithTag("NavigationSuiteItem")[1].performClick()
-        waitUntilAtLeastOneExists(hasTestTag("CollectionListScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("CollectionListScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CollectionListScreenRoot").assertIsDisplayed()
 
         // Basic collection create
         onNodeWithTag("FloatingActionButton").performClick()
         onNodeWithTag("BasicCollectionCreateButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BasicCollectionCreateScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BasicCollectionCreateScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BasicCollectionCreateScreenRoot").assertIsDisplayed()
         onNodeWithTag("CollectionNameField").requestFocus()
         onNodeWithTag("CollectionNameField").performTextInput("TestCollectionName")
-        waitUntilAtLeastOneExists(hasTestTag("CreateButton") and isEnabled(), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("CreateButton") and isEnabled(),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CreateButton").performClick()
         advanceClock()
-        waitUntilDoesNotExist(hasTestTag("BasicCollectionCreateScreenRoot"), timeoutMillis = TEST_TIMEOUT)
-        waitUntilAtLeastOneExists(hasTestTag("CollectionListScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilDoesNotExist(
+            hasTestTag("BasicCollectionCreateScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
+        waitUntilAtLeastOneExists(
+            hasTestTag("CollectionListScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CollectionListScreenRoot").assertIsDisplayed()
 
         // Collection
@@ -356,7 +395,10 @@ class NavigationTest {
         // Basic collection edit
         onNodeWithTag("EditButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("BasicCollectionEditScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("BasicCollectionEditScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("BasicCollectionEditScreenRoot").assertIsDisplayed()
         onNodeWithTag("CloseButton").performClick()
         advanceClock()
@@ -366,28 +408,49 @@ class NavigationTest {
         // Basic collection delete
         onNodeWithTag("DeleteButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("DeleteCollectionScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("DeleteCollectionScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("DeleteCollectionScreenRoot").assertIsDisplayed()
         onNodeWithTag("ConfirmButton").performClick()
         advanceClock()
-        waitUntilDoesNotExist(hasTestTag("DeleteCollectionScreenRoot"), timeoutMillis = TEST_TIMEOUT)
-        waitUntilAtLeastOneExists(hasTestTag("CollectionListScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilDoesNotExist(
+            hasTestTag("DeleteCollectionScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
+        waitUntilAtLeastOneExists(
+            hasTestTag("CollectionListScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CollectionListScreenRoot").assertIsDisplayed()
 
         // Smart collection create
         onNodeWithTag("FloatingActionButton").performClick()
         onNodeWithTag("SmartCollectionCreateButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("SmartCollectionCreateScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("SmartCollectionCreateScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("SmartCollectionCreateScreenRoot").assertIsDisplayed()
         onNodeWithTag("CollectionNameField").requestFocus()
         onNodeWithTag("CollectionNameField").performTextInput("TestCollectionName")
         onNodeWithTag("QueryField").performTextInput("Search keyword")
-        waitUntilAtLeastOneExists(hasTestTag("CreateButton") and isEnabled(), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("CreateButton") and isEnabled(),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CreateButton").performClick()
         advanceClock()
-        waitUntilDoesNotExist(hasTestTag("SmartCollectionCreateScreenRoot"), timeoutMillis = TEST_TIMEOUT)
-        waitUntilAtLeastOneExists(hasTestTag("CollectionListScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilDoesNotExist(
+            hasTestTag("SmartCollectionCreateScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
+        waitUntilAtLeastOneExists(
+            hasTestTag("CollectionListScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CollectionListScreenRoot").assertIsDisplayed()
 
         // Collection
@@ -399,7 +462,10 @@ class NavigationTest {
         // Smart collection edit
         onNodeWithTag("EditButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("SmartCollectionEditScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("SmartCollectionEditScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("SmartCollectionEditScreenRoot").assertIsDisplayed()
         onNodeWithTag("CloseButton").performClick()
         advanceClock()
@@ -409,12 +475,21 @@ class NavigationTest {
         // Smart collection delete
         onNodeWithTag("DeleteButton").performClick()
         advanceClock()
-        waitUntilAtLeastOneExists(hasTestTag("DeleteCollectionScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilAtLeastOneExists(
+            hasTestTag("DeleteCollectionScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("DeleteCollectionScreenRoot").assertIsDisplayed()
         onNodeWithTag("ConfirmButton").performClick()
         advanceClock()
-        waitUntilDoesNotExist(hasTestTag("DeleteCollectionScreenRoot"), timeoutMillis = TEST_TIMEOUT)
-        waitUntilAtLeastOneExists(hasTestTag("CollectionListScreenRoot"), timeoutMillis = TEST_TIMEOUT)
+        waitUntilDoesNotExist(
+            hasTestTag("DeleteCollectionScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
+        waitUntilAtLeastOneExists(
+            hasTestTag("CollectionListScreenRoot"),
+            timeoutMillis = TEST_TIMEOUT,
+        )
         onNodeWithTag("CollectionListScreenRoot").assertIsDisplayed()
     }
 

--- a/domain/model/build.gradle.kts
+++ b/domain/model/build.gradle.kts
@@ -12,6 +12,7 @@ kotlin {
             dependencies {
                 api(libs.kotlinx.datetime)
                 implementation(libs.kotlinx.serializationCore)
+                implementation(libs.kotlinx.serializationProtobuf)
             }
         }
     }

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/BookSettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/BookSettings.kt
@@ -4,12 +4,15 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class BookSettings(
-    val pageFormat: PageFormat = PageFormat.Default,
-    val pageScale: PageScale = PageScale.Fit,
+    @ProtoNumber(1) val pageFormat: PageFormat = PageFormat.Default,
+    @ProtoNumber(2) val pageScale: PageScale = PageScale.Fit,
 ) {
     @Serializable
     enum class PageFormat {

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/CollectionSettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/CollectionSettings.kt
@@ -4,7 +4,10 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class CollectionSettings(val recent: Boolean = true)
+data class CollectionSettings(@ProtoNumber(1) val recent: Boolean = true)

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/DisplaySettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/DisplaySettings.kt
@@ -4,10 +4,13 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class DisplaySettings(
-    val darkMode: DarkMode = DarkMode.DEVICE,
-    val restoreOnLaunch: Boolean = false,
+    @ProtoNumber(1) val darkMode: DarkMode = DarkMode.DEVICE,
+    @ProtoNumber(2) val restoreOnLaunch: Boolean = false,
 )

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/FolderSettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/FolderSettings.kt
@@ -5,11 +5,14 @@
 package com.sorrowblue.comicviewer.domain.model.settings
 
 import com.sorrowblue.comicviewer.domain.model.SupportExtension
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class FolderSettings(
-    val isAutoRefresh: Boolean = true,
-    val supportExtension: List<SupportExtension> = SupportExtension.Archive.entries,
-    val resolveImageFolder: Boolean = false,
+    @ProtoNumber(1) val isAutoRefresh: Boolean = true,
+    @ProtoNumber(2) val supportExtension: List<SupportExtension> = SupportExtension.Archive.entries,
+    @ProtoNumber(3) val resolveImageFolder: Boolean = false,
 )

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/SecuritySettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/SecuritySettings.kt
@@ -4,11 +4,14 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class SecuritySettings(
-    val password: String? = null,
-    val useBiometrics: Boolean = false,
-    val lockOnBackground: Boolean = false,
+    @ProtoNumber(1) val password: String? = null,
+    @ProtoNumber(2) val useBiometrics: Boolean = false,
+    @ProtoNumber(3) val lockOnBackground: Boolean = false,
 )

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/Settings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/Settings.kt
@@ -4,11 +4,14 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class Settings(
-    val doneTutorial: Boolean = false,
-    val useAuth: Boolean = false,
-    val restoreOnLaunch: Boolean = false,
+    @ProtoNumber(1) val doneTutorial: Boolean = false,
+    @ProtoNumber(2) val useAuth: Boolean = false,
+    @ProtoNumber(3) val restoreOnLaunch: Boolean = false,
 )

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/ViewerSettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/ViewerSettings.kt
@@ -5,19 +5,22 @@
 package com.sorrowblue.comicviewer.domain.model.settings
 
 import com.sorrowblue.comicviewer.domain.model.settings.folder.ImageFormat
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class ViewerSettings(
-    val showStatusBar: Boolean = true,
-    val showNavigationBar: Boolean = true,
-    val keepOnScreen: Boolean = false,
-    val cutWhitespace: Boolean = false,
-    val enableBrightnessControl: Boolean = false,
-    val screenBrightness: Float = 0.3f,
-    val imageQuality: Int = 75,
-    val readAheadPageCount: Int = 3,
-    val bindingDirection: BindingDirection = BindingDirection.RTL,
-    val alwaysOpenFromFirstPage: Boolean = false,
-    val imageFormat: ImageFormat = ImageFormat.ORIGINAL,
+    @ProtoNumber(1) val showStatusBar: Boolean = true,
+    @ProtoNumber(2) val showNavigationBar: Boolean = true,
+    @ProtoNumber(3) val keepOnScreen: Boolean = false,
+    @ProtoNumber(4) val cutWhitespace: Boolean = false,
+    @ProtoNumber(5) val enableBrightnessControl: Boolean = false,
+    @ProtoNumber(6) val screenBrightness: Float = 0.3f,
+    @ProtoNumber(7) val imageQuality: Int = 75,
+    @ProtoNumber(8) val readAheadPageCount: Int = 3,
+    @ProtoNumber(9) val bindingDirection: BindingDirection = BindingDirection.RTL,
+    @ProtoNumber(10) val alwaysOpenFromFirstPage: Boolean = false,
+    @ProtoNumber(11) val imageFormat: ImageFormat = ImageFormat.ORIGINAL,
 )

--- a/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/folder/FolderDisplaySettings.kt
+++ b/domain/model/src/commonMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/folder/FolderDisplaySettings.kt
@@ -5,7 +5,9 @@
 package com.sorrowblue.comicviewer.domain.model.settings.folder
 
 import com.sorrowblue.comicviewer.domain.model.bookshelf.BookshelfId
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
 /**
  * Represents the display settings for folders.
@@ -25,22 +27,31 @@ import kotlinx.serialization.Serializable
  * @property folderThumbnailOrder The order for folder thumbnails.
  * @property folderScopeOnlyList List of folder-specific settings.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class FolderDisplaySettings(
-    val fileListDisplay: FileListDisplay = FolderDisplaySettingsDefaults.fileListDisplay,
-    val gridColumnSize: GridColumnSize = FolderDisplaySettingsDefaults.gridColumnSize,
-    val sortType: SortType = FolderDisplaySettingsDefaults.sortType,
-    val folderScopeOnlyList: List<FolderScopeOnly> = emptyList(),
-    val showHiddenFiles: Boolean = FolderDisplaySettingsDefaults.DisplayHiddenFile,
-    val showFilesExtension: Boolean = FolderDisplaySettingsDefaults.DisplayFileExtension,
-    val showThumbnails: Boolean = FolderDisplaySettingsDefaults.DisplayThumbnail,
-    val isSavedThumbnail: Boolean = FolderDisplaySettingsDefaults.SavedThumbnail,
-    val fontSize: Int = FolderDisplaySettingsDefaults.FontSize,
-    val thumbnailQuality: Int = FolderDisplaySettingsDefaults.ThumbnailQuality,
-    val imageFormat: ImageFormat = FolderDisplaySettingsDefaults.imageFormat,
-    val imageScale: ImageScale = FolderDisplaySettingsDefaults.imageScale,
-    val imageFilterQuality: ImageFilterQuality = FolderDisplaySettingsDefaults.imageFilterQuality,
-    val folderThumbnailOrder: FolderThumbnailOrder =
+    @ProtoNumber(
+        1,
+    ) val fileListDisplay: FileListDisplay = FolderDisplaySettingsDefaults.fileListDisplay,
+    @ProtoNumber(
+        2,
+    ) val gridColumnSize: GridColumnSize = FolderDisplaySettingsDefaults.gridColumnSize,
+    @ProtoNumber(3) val sortType: SortType = FolderDisplaySettingsDefaults.sortType,
+    @ProtoNumber(4) val folderScopeOnlyList: List<FolderScopeOnly> = emptyList(),
+    @ProtoNumber(5) val showHiddenFiles: Boolean = FolderDisplaySettingsDefaults.DisplayHiddenFile,
+    @ProtoNumber(
+        6,
+    ) val showFilesExtension: Boolean = FolderDisplaySettingsDefaults.DisplayFileExtension,
+    @ProtoNumber(7) val showThumbnails: Boolean = FolderDisplaySettingsDefaults.DisplayThumbnail,
+    @ProtoNumber(8) val isSavedThumbnail: Boolean = FolderDisplaySettingsDefaults.SavedThumbnail,
+    @ProtoNumber(9) val fontSize: Int = FolderDisplaySettingsDefaults.FontSize,
+    @ProtoNumber(10) val thumbnailQuality: Int = FolderDisplaySettingsDefaults.ThumbnailQuality,
+    @ProtoNumber(11) val imageFormat: ImageFormat = FolderDisplaySettingsDefaults.imageFormat,
+    @ProtoNumber(12) val imageScale: ImageScale = FolderDisplaySettingsDefaults.imageScale,
+    @ProtoNumber(
+        13,
+    ) val imageFilterQuality: ImageFilterQuality = FolderDisplaySettingsDefaults.imageFilterQuality,
+    @ProtoNumber(14) val folderThumbnailOrder: FolderThumbnailOrder =
         FolderDisplaySettingsDefaults.folderThumbnailOrder,
 ) {
     /**
@@ -107,5 +118,10 @@ object FolderDisplaySettingsDefaults {
  * @property path The folder path.
  * @property sortType The sort type for the folder.
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
-data class FolderScopeOnly(val bookshelfId: BookshelfId, val path: String, val sortType: SortType)
+data class FolderScopeOnly(
+    @ProtoNumber(1) val bookshelfId: BookshelfId,
+    @ProtoNumber(2) val path: String,
+    @ProtoNumber(3) val sortType: SortType,
+)

--- a/domain/model/src/jvmMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/WindowSettings.kt
+++ b/domain/model/src/jvmMain/kotlin/com/sorrowblue/comicviewer/domain/model/settings/WindowSettings.kt
@@ -4,7 +4,9 @@
 
 package com.sorrowblue.comicviewer.domain.model.settings
 
+import kotlinx.serialization.ExperimentalSerializationApi
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.protobuf.ProtoNumber
 
 /**
  * Window settings
@@ -15,11 +17,12 @@ import kotlinx.serialization.Serializable
  * @property y Window y position
  * @property isMaximized Whether the window is maximized
  */
+@OptIn(ExperimentalSerializationApi::class)
 @Serializable
 data class WindowSettings(
-    val width: Int = 1024,
-    val height: Int = 768,
-    val x: Int = -1,
-    val y: Int = -1,
-    val isMaximized: Boolean = false,
+    @ProtoNumber(1) val width: Int = 1024,
+    @ProtoNumber(2) val height: Int = 768,
+    @ProtoNumber(3) val x: Int = -1,
+    @ProtoNumber(4) val y: Int = -1,
+    @ProtoNumber(5) val isMaximized: Boolean = false,
 )

--- a/feature/collection/add/src/commonMain/kotlin/com/sorrowblue/comicviewer/feature/collection/add/BasicCollectionAddScreen.kt
+++ b/feature/collection/add/src/commonMain/kotlin/com/sorrowblue/comicviewer/feature/collection/add/BasicCollectionAddScreen.kt
@@ -22,8 +22,7 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SheetState
 import androidx.compose.material3.SheetValue
 import androidx.compose.material3.Text
-import androidx.compose.material3.rememberModalBottomSheetState
-import androidx.compose.material3.rememberStandardBottomSheetState
+import androidx.compose.material3.rememberBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -68,7 +67,10 @@ internal fun BasicCollectionAddScreen(
     onCollectionCreateClick: () -> Unit,
     modifier: Modifier = Modifier,
     lazyListState: LazyListState = rememberLazyListState(),
-    sheetState: SheetState = rememberModalBottomSheetState(true),
+    sheetState: SheetState = rememberBottomSheetState(
+        initialValue = SheetValue.Hidden,
+        enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
+    ),
 ) {
     ModalBottomSheet(
         onDismissRequest = onDismissRequest,
@@ -139,9 +141,9 @@ private fun BasicCollectionAddScreenPreview() {
             onClick = { _, _ -> },
             onClickCollectionSort = { _ -> },
             onCollectionCreateClick = {},
-            sheetState = rememberStandardBottomSheetState(
+            sheetState = rememberBottomSheetState(
                 initialValue = SheetValue.Expanded,
-                skipHiddenState = true,
+                enabledValues = setOf(SheetValue.Hidden, SheetValue.Expanded),
             ),
         )
     }


### PR DESCRIPTION
## Changes
- `domain:model` に `kotlinx-serialization-protobuf` を追加し、各種設定クラス（Settings, BookSettings 等）の各プロパティに `@ProtoNumber` アノテーションを付与してProtobufによるシリアライズをサポートしました。
- `BasicCollectionAddScreen` において、非推奨化された `rememberModalBottomSheetState` および `rememberStandardBottomSheetState` を廃止し、新しい `rememberBottomSheetState` への移行を行いました。
- `NavigationTest` のインデント・フォーマット調整を行いました。

## Related Issues
特になし

## Testing Method
ローカルでのビルドおよび全プラットフォームのテスト実行、静的解析が正常に終了することを確認しました。
- `./gradlew reportMerge` (Detekt) -> 正常終了
- `./gradlew :app:androidApp:lintDebug` (Android Lint) -> 正常終了
- `./gradlew allTests` (テスト) -> 正常終了

## Checklist
- [x] Detekt executed
- [x] Lint executed
- [x] Tests executed
- [x] Documentation updated
