### PR TITLE
chore: temporarily disable non-jvmtest CI jobs and add report upload

### DIFF
--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -57,25 +57,25 @@ jobs:
             echo "  - Other files changed: $OTHER_FILES_CHANGED"
           fi
 
-#  lint:
-#    needs: check-commit
-#    if: needs.check-commit.outputs.should-run == 'true'
-#    uses: ./.github/workflows/lint.yml
+  lint:
+    needs: check-commit
+    if: needs.check-commit.outputs.should-run == 'true'
+    uses: ./.github/workflows/lint.yml
 
   test:
     needs: check-commit
     if: needs.check-commit.outputs.should-run == 'true'
     uses: ./.github/workflows/test.yml
 
-#  build:
-#    needs: [ lint, test ]
-#    if: needs.check-commit.outputs.should-run == 'true'
-#    uses: ./.github/workflows/build.yml
-#    secrets: inherit
+  build:
+    needs: [ lint, test ]
+    if: needs.check-commit.outputs.should-run == 'true'
+    uses: ./.github/workflows/build.yml
+    secrets: inherit
 
   allchecks:
     name: All Checks Passed
-    needs: [ check-commit, test ]
+    needs: [ check-commit, lint, test, build ]
     if: always() && cancelled() != true && needs.check-commit.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -83,4 +83,4 @@ jobs:
         with:
           poll: false
           delay: 0
-          checks_include: '^check-commit,^test'
+          checks_include: '^check-commit,^lint,^test,^build'

--- a/.github/workflows/lint-test-build.yml
+++ b/.github/workflows/lint-test-build.yml
@@ -57,25 +57,25 @@ jobs:
             echo "  - Other files changed: $OTHER_FILES_CHANGED"
           fi
 
-  lint:
-    needs: check-commit
-    if: needs.check-commit.outputs.should-run == 'true'
-    uses: ./.github/workflows/lint.yml
+#  lint:
+#    needs: check-commit
+#    if: needs.check-commit.outputs.should-run == 'true'
+#    uses: ./.github/workflows/lint.yml
 
   test:
     needs: check-commit
     if: needs.check-commit.outputs.should-run == 'true'
     uses: ./.github/workflows/test.yml
 
-  build:
-    needs: [ lint, test ]
-    if: needs.check-commit.outputs.should-run == 'true'
-    uses: ./.github/workflows/build.yml
-    secrets: inherit
+#  build:
+#    needs: [ lint, test ]
+#    if: needs.check-commit.outputs.should-run == 'true'
+#    uses: ./.github/workflows/build.yml
+#    secrets: inherit
 
   allchecks:
     name: All Checks Passed
-    needs: [ check-commit, lint, test, build ]
+    needs: [ check-commit, test ]
     if: always() && cancelled() != true && needs.check-commit.outputs.should-run == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -83,4 +83,4 @@ jobs:
         with:
           poll: false
           delay: 0
-          checks_include: '^check-commit,^lint,^test,^build'
+          checks_include: '^check-commit,^test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,8 +6,12 @@ on:
 jobs:
 
   unit-test:
-    name: Unit Test
+    name: Unit Test (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
 
     services:
       samba: &samba_settings
@@ -41,7 +45,7 @@ jobs:
         if: cancelled() != true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
-          name: 'Unit Test'
+          name: 'Unit Test (${{ matrix.shard }})'
           path: '**/build/test-results/*/TEST-*.xml'
           reporter: 'java-junit'
           fail-on-error: false
@@ -49,7 +53,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: jvm-test-reports
+          name: jvm-test-reports-${{ matrix.shard }}
           path: |
             **/build/reports/tests/jvmTest/**/*
             **/build/test-results/jvmTest/**/*

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,7 +31,7 @@ jobs:
         uses: ./.github/actions/setup-java-gradle
       - name: Run Unit Tests
         run: >
-          ./gradlew jvmTest testAndroidHostTest --continue
+          ./gradlew jvmTest --continue
           -PsmbHost=localhost
           -PsmbPort=445
           -PsmbUsername=testuser
@@ -45,47 +45,56 @@ jobs:
           path: '**/build/test-results/*/TEST-*.xml'
           reporter: 'java-junit'
           fail-on-error: false
-
-  instrumentation-test:
-    name: Instrumentation Test
-    runs-on: ubuntu-latest
-
-    services:
-      samba: *samba_settings
-
-    steps:
-      - name: Enable KVM group perms
-        run: |
-          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-          sudo udevadm control --reload-rules
-          sudo udevadm trigger --name-match=kvm
-      - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - name: Setup samba
-        uses: ./.github/actions/setup_samba
-      - name: Setup Java and Gradle
-        uses: ./.github/actions/setup-java-gradle
-      - name: Run Instrumentation tests
-        run: ./gradlew pixel7pro35AndroidDeviceTest --continue
-            -PsmbHost=10.0.2.2
-            -PsmbPort=445
-            -PsmbUsername=testuser
-            -PsmbPassword=testpass
-            -PsmbPath="/testshare/testfolder/"
-      - name: Upload Test Report
-        if: cancelled() != true
-        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
-        with:
-          name: 'Instrumentation Test'
-          path: '**/build/outputs/*Test-results/**/TEST-*.xml'
-          reporter: 'java-junit'
-          fail-on-error: false
-      - name: Upload Crash Logs on Failure
-        if: failure()
+      - name: Upload JVM Test Reports on Failure
+        if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: android-crash-logs
+          name: jvm-test-reports
           path: |
-            **/build/outputs/androidTest-results/managedDevice/**/*.txt
-            **/build/reports/androidTests/managedDevice/**/*
+            **/build/reports/tests/jvmTest/**/*
+            **/build/test-results/jvmTest/**/*
           if-no-files-found: ignore
+
+#  instrumentation-test:
+#    name: Instrumentation Test
+#    runs-on: ubuntu-latest
+#
+#    services:
+#      samba: *samba_settings
+#
+#    steps:
+#      - name: Enable KVM group perms
+#        run: |
+#          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+#          sudo udevadm control --reload-rules
+#          sudo udevadm trigger --name-match=kvm
+#      - name: Checkout
+#        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+#      - name: Setup samba
+#        uses: ./.github/actions/setup_samba
+#      - name: Setup Java and Gradle
+#        uses: ./.github/actions/setup-java-gradle
+#      - name: Run Instrumentation tests
+#        run: ./gradlew pixel7pro35AndroidDeviceTest --continue
+#            -PsmbHost=10.0.2.2
+#            -PsmbPort=445
+#            -PsmbUsername=testuser
+#            -PsmbPassword=testpass
+#            -PsmbPath="/testshare/testfolder/"
+#      - name: Upload Test Report
+#        if: cancelled() != true
+#        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+#        with:
+#          name: 'Instrumentation Test'
+#          path: '**/build/outputs/*Test-results/**/TEST-*.xml'
+#          reporter: 'java-junit'
+#          fail-on-error: false
+#      - name: Upload Crash Logs on Failure
+#        if: failure()
+#        uses: actions/upload-artifact@v7
+#        with:
+#          name: android-crash-logs
+#          path: |
+#            **/build/outputs/androidTest-results/managedDevice/**/*.txt
+#            **/build/reports/androidTests/managedDevice/**/*
+#          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,33 +5,9 @@ on:
 
 jobs:
 
-  unit-test:
-    name: Unit Test (${{ matrix.tasks }} - ${{ matrix.shard }})
+  jvm-test:
+    name: JVM Test
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - shard: 1
-            tasks: "jvmTest testAndroidHostTest"
-          - shard: 2
-            tasks: "jvmTest testAndroidHostTest"
-          - shard: 3
-            tasks: "jvmTest testAndroidHostTest"
-          - shard: 4
-            tasks: "jvmTest testAndroidHostTest"
-          - shard: 5
-            tasks: "jvmTest testAndroidHostTest"
-          - shard: 6
-            tasks: "jvmTest"
-          - shard: 7
-            tasks: "jvmTest"
-          - shard: 8
-            tasks: "jvmTest"
-          - shard: 9
-            tasks: "jvmTest"
-          - shard: 10
-            tasks: "jvmTest"
 
     services:
       samba: &samba_settings
@@ -53,9 +29,9 @@ jobs:
         uses: ./.github/actions/setup_samba
       - name: Setup Java and Gradle
         uses: ./.github/actions/setup-java-gradle
-      - name: Run Unit Tests
+      - name: Run JVM Tests
         run: >
-          ./gradlew ${{ matrix.tasks }} --continue
+          ./gradlew jvmTest --continue
           -PsmbHost=localhost
           -PsmbPort=445
           -PsmbUsername=testuser
@@ -65,60 +41,100 @@ jobs:
         if: cancelled() != true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
-          name: 'Unit Test (${{ matrix.tasks }} - ${{ matrix.shard }})'
+          name: 'JVM Test'
           path: '**/build/test-results/*/TEST-*.xml'
           reporter: 'java-junit'
           fail-on-error: false
-      - name: Upload JVM/Android Test Reports on Failure
+      - name: Upload JVM Test Reports on Failure
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: test-reports-${{ matrix.shard }}
+          name: jvm-test-reports
           path: |
-            **/build/reports/tests/**/*
-            **/build/test-results/**/*
+            **/build/reports/tests/jvmTest/**/*
+            **/build/test-results/jvmTest/**/*
           if-no-files-found: ignore
 
-#  instrumentation-test:
-#    name: Instrumentation Test
-#    runs-on: ubuntu-latest
-#
-#    services:
-#      samba: *samba_settings
-#
-#    steps:
-#      - name: Enable KVM group perms
-#        run: |
-#          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
-#          sudo udevadm control --reload-rules
-#          sudo udevadm trigger --name-match=kvm
-#      - name: Checkout
-#        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-#      - name: Setup samba
-#        uses: ./.github/actions/setup_samba
-#      - name: Setup Java and Gradle
-#        uses: ./.github/actions/setup-java-gradle
-#      - name: Run Instrumentation tests
-#        run: ./gradlew pixel7pro35AndroidDeviceTest --continue
-#            -PsmbHost=10.0.2.2
-#            -PsmbPort=445
-#            -PsmbUsername=testuser
-#            -PsmbPassword=testpass
-#            -PsmbPath="/testshare/testfolder/"
-#      - name: Upload Test Report
-#        if: cancelled() != true
-#        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
-#        with:
-#          name: 'Instrumentation Test'
-#          path: '**/build/outputs/*Test-results/**/TEST-*.xml'
-#          reporter: 'java-junit'
-#          fail-on-error: false
-#      - name: Upload Crash Logs on Failure
-#        if: failure()
-#        uses: actions/upload-artifact@v7
-#        with:
-#          name: android-crash-logs
-#          path: |
-#            **/build/outputs/androidTest-results/managedDevice/**/*.txt
-#            **/build/reports/androidTests/managedDevice/**/*
-#          if-no-files-found: ignore
+  android-host-test:
+    name: Android Host Test
+    runs-on: ubuntu-latest
+
+    services:
+      samba: *samba_settings
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup samba
+        uses: ./.github/actions/setup_samba
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
+      - name: Run Android Host Tests
+        run: >
+          ./gradlew testAndroidHostTest --continue
+          -PsmbHost=localhost
+          -PsmbPort=445
+          -PsmbUsername=testuser
+          -PsmbPassword=testpass
+          -PsmbPath="/testshare/testfolder/"
+      - name: Upload Test Report
+        if: cancelled() != true
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        with:
+          name: 'Android Host Test'
+          path: '**/build/test-results/*/TEST-*.xml'
+          reporter: 'java-junit'
+          fail-on-error: false
+      - name: Upload Android Host Test Reports on Failure
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-host-test-reports
+          path: |
+            **/build/reports/tests/testAndroidHostTest/**/*
+            **/build/test-results/testAndroidHostTest/**/*
+          if-no-files-found: ignore
+
+  instrumentation-test:
+    name: Instrumentation Test
+    runs-on: ubuntu-latest
+
+    services:
+      samba: *samba_settings
+
+    steps:
+      - name: Enable KVM group perms
+        run: |
+          echo 'KERNEL=="kvm", GROUP="kvm", MODE="0666", OPTIONS+="static_node=kvm"' | sudo tee /etc/udev/rules.d/99-kvm4all.rules
+          sudo udevadm control --reload-rules
+          sudo udevadm trigger --name-match=kvm
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - name: Setup samba
+        uses: ./.github/actions/setup_samba
+      - name: Setup Java and Gradle
+        uses: ./.github/actions/setup-java-gradle
+      - name: Run Instrumentation tests
+        run: ./gradlew pixel7pro35AndroidDeviceTest --continue
+            -PsmbHost=10.0.2.2
+            -PsmbPort=445
+            -PsmbUsername=testuser
+            -PsmbPassword=testpass
+            -PsmbPath="/testshare/testfolder/"
+      - name: Upload Test Report
+        if: cancelled() != true
+        uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
+        with:
+          name: 'Instrumentation Test'
+          path: '**/build/outputs/*Test-results/**/TEST-*.xml'
+          reporter: 'java-junit'
+          fail-on-error: false
+      - name: Upload Crash Logs on Failure
+        if: failure()
+        uses: actions/upload-artifact@v7
+        with:
+          name: android-crash-logs
+          path: |
+            **/build/outputs/androidTest-results/managedDevice/**/*.txt
+            **/build/reports/androidTests/managedDevice/**/*
+          if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,12 +6,32 @@ on:
 jobs:
 
   unit-test:
-    name: Unit Test (${{ matrix.shard }})
+    name: Unit Test (${{ matrix.tasks }} - ${{ matrix.shard }})
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10]
+        include:
+          - shard: 1
+            tasks: "jvmTest testAndroidHostTest"
+          - shard: 2
+            tasks: "jvmTest testAndroidHostTest"
+          - shard: 3
+            tasks: "jvmTest testAndroidHostTest"
+          - shard: 4
+            tasks: "jvmTest testAndroidHostTest"
+          - shard: 5
+            tasks: "jvmTest testAndroidHostTest"
+          - shard: 6
+            tasks: "jvmTest"
+          - shard: 7
+            tasks: "jvmTest"
+          - shard: 8
+            tasks: "jvmTest"
+          - shard: 9
+            tasks: "jvmTest"
+          - shard: 10
+            tasks: "jvmTest"
 
     services:
       samba: &samba_settings
@@ -35,7 +55,7 @@ jobs:
         uses: ./.github/actions/setup-java-gradle
       - name: Run Unit Tests
         run: >
-          ./gradlew jvmTest --continue
+          ./gradlew ${{ matrix.tasks }} --continue
           -PsmbHost=localhost
           -PsmbPort=445
           -PsmbUsername=testuser
@@ -45,18 +65,18 @@ jobs:
         if: cancelled() != true
         uses: dorny/test-reporter@a43b3a5f7366b97d083190328d2c652e1a8b6aa2 # v3
         with:
-          name: 'Unit Test (${{ matrix.shard }})'
+          name: 'Unit Test (${{ matrix.tasks }} - ${{ matrix.shard }})'
           path: '**/build/test-results/*/TEST-*.xml'
           reporter: 'java-junit'
           fail-on-error: false
-      - name: Upload JVM Test Reports on Failure
+      - name: Upload JVM/Android Test Reports on Failure
         if: always()
         uses: actions/upload-artifact@v7
         with:
-          name: jvm-test-reports-${{ matrix.shard }}
+          name: test-reports-${{ matrix.shard }}
           path: |
-            **/build/reports/tests/jvmTest/**/*
-            **/build/test-results/jvmTest/**/*
+            **/build/reports/tests/**/*
+            **/build/test-results/**/*
           if-no-files-found: ignore
 
 #  instrumentation-test:


### PR DESCRIPTION
## Changes
`jvmTest` が不安定（flaky）になっている問題を調査するため、一時的に CI の実行範囲を制限し、詳細ログを取得できるようにしました。

- `lint-test-build.yml` 内の `lint` ジョブ、`build` ジョブを一時的に無効化。
- `test.yml` 内の `instrumentation-test` ジョブを一時的に無効化。
- `test.yml` の `unit-test` ジョブにおいて、Android テスト (`testAndroidHostTest`) を除外して `jvmTest` のみを実行するように変更。
- `unit-test` ジョブの最後に `actions/upload-artifact` を追加し、テスト失敗時または実行完了時に JVM テストのログおよび HTML レポート (`jvm-test-reports`) をダウンロードできるようにしました。

## Related Issues
特になし

## Testing Method
GitHub Actions 上でワークフロー定義が正しく認識され、`jvmTest` のみが実行されること、およびアーティファクトのアップロードが行われることを確認します。

## Checklist
- [x] Detekt executed
- [x] Lint executed
- [x] Tests executed
- [x] Documentation updated
